### PR TITLE
rename brew cask gpgtools to gpg-suite

### DIFF
--- a/config.js
+++ b/config.js
@@ -51,7 +51,7 @@ module.exports = {
     //'diffmerge',
     //'dropbox',
     //'evernote',
-    'gpgtools',
+    'gpg-suite',
     //'ireadfast',
     'iterm2',
     'little-snitch',


### PR DESCRIPTION
brew cask gpgtools has been renamed to gpg-suite
https://github.com/Homebrew/homebrew-cask/issues/39862