### PR TITLE
Remove inactive Beerpay link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Beerpay](https://beerpay.io/atomantic/dotfiles/badge.svg?style=flat-square)](https://beerpay.io/atomantic/dotfiles)
-
 # \\[._.]/ - Hi, I'm the MacOS bot
 
 I will update your MacOS machine with Better™ system defaults, preferences, software configuration and even auto-install some handy development tools and apps that my developer friends find helpful.


### PR DESCRIPTION
https://beerpay.io/atomantic/dotfiles responds with 404 and 
https://beerpay.io/atomantic doesn't list anything resembling this project.

I'm suggesting to either remove the link or reinstate the dotfiles Beerpay page. 🍻