### PR TITLE
Adds information about git over https

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ cd ~/.dotfiles;
 * When it finishes, open iTerm and press `Command + ,` to open preferences. Under Profiles > Colors, select "Load Presets" and choose the `Solarized Dark Patch` scheme. If it isn't there for some reason, import it from `~/.dotfiles/configs` -- you may also need to select the `Hack` font and check the box for non-ascii font and set to `Roboto Mono For Powerline` (I've had mixed results for automating these settings--love a pull request that improves this)
 * I've also found that you need to reboot before fast key repeat will be enabled
 
+> Note: if you have problems cloning the submodules behind proxy, you can use this command to convert `git://` to `https://`: `git config --global url.https://github.com/.insteadOf git://github.com/`
+
 > Note: running install.sh is idempotent. You can run it again and again as you add new features or software to the scripts! I'll regularly add new configurations so keep an eye on this repo as it grows and optimizes.
 
 ## Restoring Dotfiles


### PR DESCRIPTION
I got this error on submodules because I'm behind a proxy. This addition will inform other users how to fix it.

```
Submodule 'homedir/.vim/bundle/Vundle.vim' (git://github.com/VundleVim/Vundle.vim.git) registered for path 'homedir/.vim/bundle/Vundle.vim'
Submodule 'oh-my-zsh' (git://github.com/robbyrussell/oh-my-zsh.git) registered for path 'oh-my-zsh'
Submodule 'z-zsh' (git://github.com/sjl/z-zsh.git) registered for path 'z-zsh'
Cloning into '/Users/xj19re/.dotfiles/homedir/.vim/bundle/Vundle.vim'...
fatal: unable to look up github.com (port 9418) (nodename nor servname provided, or not known)
```