### PR TITLE
Update desktop img logic, remove deprecated `brew cask cleanup`

### DIFF
--- a/config.js
+++ b/config.js
@@ -93,5 +93,17 @@ module.exports = {
     'trash',
     'vtop'
     // ,'yo'
-  ]
+  ],
+  mas: [
+    //com.if.Amphetamine (4.1.6)
+    '937984704',
+    //net.shinyfrog.bear (1.6.15)
+    '1091189122',
+    //com.monosnap.monosnap (3.5.8)
+    '540348655',
+    //com.app77.pwsafemac (4.17)
+    '520993579',
+    //com.apple.dt.Xcode (10.2.1)
+    '497799835',
+  ],
 };

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ inquirer.prompt([{
 
   const tasks = [];
 
-  ['brew', 'cask', 'npm', 'gem'].forEach( type => {
+  ['brew', 'cask', 'npm', 'gem', 'mas'].forEach( type => {
     if(config[type] && config[type].length){
       tasks.push((cb)=>{
         console.info(emoji.get('coffee'), ' installing '+type+' packages')

--- a/install.sh
+++ b/install.sh
@@ -129,13 +129,14 @@ fi
 # Wallpaper
 # ###########################################################
 MD5_NEWWP=$(md5 img/wallpaper.jpg | awk '{print $4}')
-MD5_OLDWP=$(md5 /System/Library/CoreServices/DefaultDesktop.jpg | awk '{print $4}')
+MD5_OLDWP=$(md5 /System/Library/CoreServices/DefaultDesktop.* | awk '{print $4}')
 if [[ "$MD5_NEWWP" != "$MD5_OLDWP" ]]; then
   read -r -p "Do you want to use the project's custom desktop wallpaper? [y|N] " response
   if [[ $response =~ (yes|y|Y) ]]; then
     running "Set a custom wallpaper image"
     # rm -rf ~/Library/Application Support/Dock/desktoppicture.db
     bot "I will backup system wallpapers in ~/.dotfiles/img/"
+    sudo cp /System/Library/CoreServices/DefaultDesktop.heic img/DefaultDesktop.heic
     sudo cp /System/Library/CoreServices/DefaultDesktop.jpg img/DefaultDesktop.jpg > /dev/null 2>&1
     sudo cp /Library/Desktop\ Pictures/El\ Capitan.jpg img/El\ Capitan.jpg > /dev/null 2>&1
     sudo cp /Library/Desktop\ Pictures/Sierra.jpg img/Sierra.jpg > /dev/null 2>&1
@@ -1197,6 +1198,6 @@ for app in "Activity Monitor" "Address Book" "Calendar" "Contacts" "cfprefsd" \
   killall "${app}" > /dev/null 2>&1
 done
 
-brew update && brew upgrade && brew cleanup && brew cask cleanup
+brew update && brew upgrade && brew cleanup
 
 bot "Woot! All done"

--- a/lib_sh/requirers.sh
+++ b/lib_sh/requirers.sh
@@ -7,16 +7,12 @@
 
 # source ./echos.sh
 
-function require_cask() {
-    running "brew cask $1"
-    brew cask list $1 > /dev/null 2>&1 | true
-    if [[ ${PIPESTATUS[0]} != 0 ]]; then
-        action "brew cask install $1 $2"
-        brew cask install $1
-        if [[ $? != 0 ]]; then
-            error "failed to install $1! aborting..."
-            # exit -1
-        fi
+function require_apm() {
+    running "checking atom plugin: $1"
+    apm list --installed --bare | grep $1@ > /dev/null
+    if [[ $? != 0 ]]; then
+        action "apm install $1"
+        apm install $1
     fi
     ok
 }
@@ -35,22 +31,44 @@ function require_brew() {
     ok
 }
 
-function require_node(){
-    running "node -v"
-    node -v
-    if [[ $? != 0 ]]; then
-        action "node not found, installing via homebrew"
-        brew install node
+function require_cask() {
+    running "brew cask $1"
+    brew cask list $1 > /dev/null 2>&1 | true
+    if [[ ${PIPESTATUS[0]} != 0 ]]; then
+        action "brew cask install $1 $2"
+        brew cask install $1
+        if [[ $? != 0 ]]; then
+            error "failed to install $1! aborting..."
+            # exit -1
+        fi
     fi
     ok
 }
 
 function require_gem() {
     running "gem $1"
-    if [[ $(gem list --local | grep $1 | head -1 | cut -d' ' -f1) != $1 ]];
-        then
-            action "gem install $1"
-            gem install $1
+    if [[ $(gem list --local | grep $1 | head -1 | cut -d' ' -f1) != $1 ]]; then
+        action "gem install $1"
+        gem install $1
+    fi
+    ok
+}
+
+function require_mas() {
+    running "mas $1"
+    if [[ $(mas list | grep $1 | head -1 | cut -d' ' -f1) != $1 ]]; then
+        action "mas install $1"
+        mas install $1
+    fi
+    ok
+}
+
+function require_node(){
+    running "node -v"
+    node -v
+    if [[ $? != 0 ]]; then
+        action "node not found, installing via homebrew"
+        brew install node
     fi
     ok
 }
@@ -67,21 +85,10 @@ function require_npm() {
     ok
 }
 
-function require_apm() {
-    running "checking atom plugin: $1"
-    apm list --installed --bare | grep $1@ > /dev/null
-    if [[ $? != 0 ]]; then
-        action "apm install $1"
-        apm install $1
-    fi
-    ok
-}
-
 function sourceNVM(){
     export NVM_DIR=~/.nvm
     source $(brew --prefix nvm)/nvm.sh
 }
-
 
 function require_nvm() {
     mkdir -p ~/.nvm


### PR DESCRIPTION
The new default desktop image in Catalina is `/System/Library/CoreServices/DefaultDesktop.heic` (not `jpg`).  

Updated a couple desktop image commands related to this.  Also removed `brew cask cleanup` as it has been deprecated and rolled into `brew cleanup` for some time.

https://github.com/Homebrew/brew/issues/4660