### PR TITLE
chore: disable GEMINI_SANDBOX=docker env var

### DIFF
--- a/homedir/.zshrc
+++ b/homedir/.zshrc
@@ -52,7 +52,7 @@ unsetopt correct
 # run fortune on new terminal :)
 #fortune
 
-export GEMINI_SANDBOX=docker
+#export GEMINI_SANDBOX=docker
 
 # NVM initialization (added by install.sh)
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
## Summary
- Disables the `GEMINI_SANDBOX=docker` environment variable in `.zshrc`

## Context
Local commit that was ahead of remote, pushed as part of GitHub maintenance audit.