### PR TITLE
fix: suppress p10k instant prompt warning

### DIFF
--- a/homedir/.zshrc
+++ b/homedir/.zshrc
@@ -1,6 +1,7 @@
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
 # Initialization code that may require console input (password prompts, [y/n]
 # confirmations, etc.) must go above this block; everything else may go below.
+typeset -g POWERLEVEL9K_INSTANT_PROMPT=quiet
 if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi


### PR DESCRIPTION
## Summary
- Adds `typeset -g POWERLEVEL9K_INSTANT_PROMPT=quiet` before the instant prompt block in `.zshrc`
- Suppresses the console output warning during zsh initialization while keeping instant prompt enabled

## Test plan
- [ ] Open a new terminal and verify no P10k instant prompt warning appears
- [ ] Verify zsh still starts quickly with instant prompt active

🤖 Generated with [Claude Code](https://claude.com/claude-code)