### PR TITLE
chore(git): drop deprecated templatedir, modernize git-lfs filter

### DIFF
--- a/homedir/.gitconfig
+++ b/homedir/.gitconfig
@@ -162,10 +162,6 @@
 
 [diff]
   tool = vimdiff
-
-[init]
-  templatedir = ~/.dotfiles/.git_template
-
 [merge]
     tool = vscode
 [mergetool "vscode"]
@@ -196,8 +192,9 @@
   smudge = git media smudge %f
 
 [filter "lfs"]
-  clean = git-lfs clean %f
-  smudge = git-lfs smudge %f
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
   required = true
+	process = git-lfs filter-process
 [pull]
 	rebase = true


### PR DESCRIPTION
## What

- Remove the deprecated `[init] templatedir = ~/.dotfiles/.git_template` block.
- Modernize the `[filter "lfs"]` config to the form `git lfs install` writes today:
  - `clean`/`smudge` use the explicit `-- %f` argument separator
  - add `process = git-lfs filter-process` (the batch filter protocol, much faster on repos with many LFS files)

## Why

`templatedir` is no longer used by this setup, and the old LFS filter lines predate the `filter-process` protocol. These are non-destructive correctness/perf cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)