### PR TITLE
feat: add gh/glab CLIs, little-snitch + tailscale, ~/.local/bin on PATH

### DIFF
--- a/homedir/.zshrc
+++ b/homedir/.zshrc
@@ -61,3 +61,4 @@ export NVM_DIR="$HOME/.nvm"
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+export PATH="$HOME/.local/bin:$PATH"

--- a/software/brew.list
+++ b/software/brew.list
@@ -18,6 +18,10 @@ gawk
 # http://www.lcdf.org/gifsicle/ (because I'm a gif junky)
 gifsicle
 gnupg
+# GitHub CLI: https://cli.github.com
+gh
+# GitLab CLI: https://gitlab.com/gitlab-org/cli
+glab
 # Install GNU `sed` (PATH updated automatically during install)
 gnu-sed
 # Install GNU grep (PATH updated automatically during install)

--- a/software/cask.list
+++ b/software/cask.list
@@ -12,7 +12,7 @@ docker
 #gpg-suite
 #ireadfast
 iterm2
-#little-snitch
+little-snitch
 #macbreakz
 #micro-snitch
 #signal
@@ -20,6 +20,7 @@ iterm2
 #sizeup
 #sketchup
 slack
+tailscale
 #the-unarchiver
 #torbrowser
 #transmission


### PR DESCRIPTION
## What

- **`software/brew.list`** — add `gh` (GitHub CLI) and `glab` (GitLab CLI)
- **`software/cask.list`** — enable `little-snitch`, add `tailscale`
- **`homedir/.zshrc`** — prepend `~/.local/bin` to `PATH` so user-local binaries (pipx, uv tools, etc.) resolve

All additive, non-destructive defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)