### PR TITLE
feat: machine-local override files (.zshrc.local, .gitignore.local) + bump stevenblack-hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,14 @@ id_rsa
 # desktop image backups
 img/*.backup.jpg
 node_modules
-# personal swap gitconfigs
+# personal swap gitconfigs / per-identity gitconfigs (e.g. .gitconfig-work)
 homedir/.gitconfig_*
-# local git identity written by install.sh (normally lives at ~/.gitconfig.local,
-# outside the repo; ignored here too in case it lands in the repo tree)
+homedir/.gitconfig-*
+# machine-local override files written by install.sh. These normally live at ~/
+# (outside the repo); ignored here too in case they ever land in the repo tree.
 homedir/.gitconfig.local
+homedir/.gitignore.local
+homedir/.zshrc.local
 homedir/.vim/backup/*
 !homedir/.vim/backup/.gitignore
 homedir/.vim/temp/*

--- a/README.md
+++ b/README.md
@@ -88,11 +88,24 @@ cd ~/.dotfiles;
 - **Back up** any existing dotfile it is about to replace into `~/.dotfiles_backup/<timestamp>/` (restore later with `./restore.sh`).
 - **Symlink** the files in `homedir/` into your `$HOME` (`.zshrc`, `.vimrc`, `.gitconfig`, `.shellaliases`, `.shellfn`, etc.).
 - Prompt to configure your **git identity** (name, email, github username) and write it to the untracked `~/.gitconfig.local` — kept out of version control and pulled into `~/.gitconfig` via `[include]`, so your personal info never lands in the repo.
+- Seed your **machine-local override files** (see below) so per-machine, private/proprietary settings stay out of the repo.
 - Optionally overwrite `/etc/hosts` using [StevenBlack/hosts](https://github.com/StevenBlack/hosts) (add your own entries in `configs/hosts.local`).
 - Apply macOS system tweaks — Finder, Dock, security, and more (see [Settings](#settings)).
 - Prompt, **per category**, to install software: Homebrew CLI tools & desktop apps, npm globals, Mac App Store apps, and Ruby gems (see [Software Installation](#software-installation)).
 
 Every prompt can be declined, so you can run it just to apply the parts you want. To upgrade an existing install later, use [`./update.sh`](#updating) instead — it pulls the latest code and then runs `install.sh` for you.
+
+### Machine-local overrides (private / per-machine settings)
+
+Some settings are specific to one machine (work tools, proprietary config) and must **not** be committed or synced to your other machines. Keep them in these untracked override files — `install.sh` seeds them and then never touches them again, and they are git-ignored so they can't be committed:
+
+| File | Loaded by | Use it for |
+|------|-----------|------------|
+| `~/.gitconfig.local` | `[include]` in `~/.gitconfig` | git identity + any per-machine git config |
+| `~/.gitignore.local` | git's `core.excludesfile` (seeded from the shared `homedir/.gitignore` baseline) | global ignore entries, e.g. internal tool directories |
+| `~/.zshrc.local` | `source` at the end of `~/.zshrc` | machine-local shell config, `PATH` entries, completions |
+
+Edit these freely — they belong to you. The tracked files in `homedir/` stay clean, so `git pull` / `./update.sh` never conflicts with your local customizations. (`~/.gitignore.local` is a one-time copy of the shared baseline plus your additions; if the baseline changes later you can re-copy the top section.)
 
 - When it finishes, open iTerm and press `Command + ,` to open preferences. Under Profiles > Colors, select "Load Presets" and choose the `Solarized Dark Patch` scheme. If it isn't there for some reason, import it from `~/.dotfiles/configs` -- you may also need to select the `Hack` font and check the box for non-ascii font and set to `Roboto Mono For Powerline` (I've had mixed results for automating these settings--love a pull request that improves this)
 - I've also found that you need to reboot before fast key repeat will be enabled

--- a/homedir/.gitconfig
+++ b/homedir/.gitconfig
@@ -37,7 +37,10 @@
   fontdiff = -family Monaco -size 10 -weight normal -slant roman -underline 0 -overstrike 0
 
 [core]
-  excludesfile = ~/.gitignore
+  # Global ignore lives in ~/.gitignore.local (untracked, machine-local) so each
+  # machine can add private/proprietary entries without committing them.
+  # install.sh seeds it from the shared baseline (homedir/.gitignore).
+  excludesfile = ~/.gitignore.local
   quotepath = false
   # line endings
   # force LF during add

--- a/homedir/.zshrc
+++ b/homedir/.zshrc
@@ -62,3 +62,8 @@ export NVM_DIR="$HOME/.nvm"
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 export PATH="$HOME/.local/bin:$PATH"
+
+# Machine-local shell settings — NOT tracked, NOT synced to other machines.
+# Put private/proprietary or per-machine config in ~/.zshrc.local (created by
+# install.sh). Keeps this committed .zshrc clean across machines.
+[ -f ~/.zshrc.local ] && source ~/.zshrc.local

--- a/install.sh
+++ b/install.sh
@@ -275,6 +275,12 @@ if [[ $response =~ (y|yes|Y) ]]; then
     if [[ $file == "." || $file == ".." ]]; then
       continue
     fi
+    # .gitignore is NOT symlinked into ~/: it is the shared baseline that seeds
+    # the machine-local ~/.gitignore.local (git's core.excludesfile). See the
+    # "Machine-local override files" step below.
+    if [[ $file == ".gitignore" ]]; then
+      continue
+    fi
     running "~/$file"
     # if the file exists:
     if [[ -e ~/$file ]]; then
@@ -290,6 +296,46 @@ if [[ $response =~ (y|yes|Y) ]]; then
   done
 
   popd > /dev/null 2>&1
+fi
+
+# ###########################################################
+# Machine-local override files
+# ###########################################################
+# These untracked files let each machine add private/proprietary settings that
+# must not be committed or synced to other machines. They are seeded once and
+# then owned by you (install.sh never overwrites them).
+bot "Setting up machine-local override files (~/.zshrc.local, ~/.gitignore.local)"
+
+# ~/.gitignore.local is git's core.excludesfile (see homedir/.gitconfig). Seed it
+# from the shared baseline so the defaults still apply, then you can append your
+# own machine-local ignores below the marker.
+gitignore_local="$HOME/.gitignore.local"
+if [ ! -f "$gitignore_local" ]; then
+  running "seeding ~/.gitignore.local from the shared baseline (homedir/.gitignore)"
+  {
+    cat ./homedir/.gitignore
+    echo ""
+    echo "# ----------------------------------------------------------------------"
+    echo "# Machine-local ignores below — NOT tracked, NOT synced to other machines."
+    echo "# Add private/proprietary entries here (e.g. internal tool directories)."
+    echo "# ----------------------------------------------------------------------"
+  } >"$gitignore_local"
+  ok
+else
+  ok "~/.gitignore.local already exists; leaving it untouched"
+fi
+
+# ~/.zshrc.local is sourced at the end of ~/.zshrc.
+zshrc_local="$HOME/.zshrc.local"
+if [ ! -f "$zshrc_local" ]; then
+  running "creating ~/.zshrc.local for machine-local shell settings"
+  {
+    echo "# Machine-local zsh settings — NOT tracked, NOT synced to other machines."
+    echo "# Sourced at the end of ~/.zshrc. Add private/proprietary settings here."
+  } >"$zshrc_local"
+  ok
+else
+  ok "~/.zshrc.local already exists; leaving it untouched"
 fi
 
 bot "VIM Setup"


### PR DESCRIPTION
Follow-up to #142. Extends the "keep personal stuff out of tracked files" pattern to the shell config and the global gitignore, and bumps the hosts blocklist.

## Machine-local override files

Some settings are specific to one machine (work tools, proprietary config) and must **not** be committed or synced to other machines. This adds untracked, per-machine override files — `install.sh` seeds them once and never overwrites them, and they're git-ignored:

| File | Loaded by | For |
|------|-----------|-----|
| `~/.gitconfig.local` | `[include]` in `~/.gitconfig` (from #142) | git identity + per-machine git config |
| `~/.gitignore.local` | git's `core.excludesfile`, **seeded from the shared `homedir/.gitignore` baseline** | global ignores, e.g. internal tool dirs |
| `~/.zshrc.local` | `source` at the end of `~/.zshrc` | machine-local shell config / `PATH` / completions |

Changes:
- **`homedir/.zshrc`** — sources `~/.zshrc.local` at the end (if present).
- **`homedir/.gitconfig`** — `core.excludesfile` now points at `~/.gitignore.local` (was `~/.gitignore`).
- **`install.sh`** — new idempotent step seeds `~/.gitignore.local` (baseline + a "machine-local entries" marker) and a `~/.zshrc.local` stub; existing files are left untouched. `.gitignore` is no longer symlinked into `~/` (it's the baseline/seed template now, not a live dotfile — symlinking it would be a footgun since git reads `~/.gitignore.local`).
- **`.gitignore`** — adds `homedir/.gitconfig-*` (so per-identity configs like `.gitconfig-atomantic` aren't flagged) plus defensive entries for the `.local` override files.
- **`README.md`** — documents the override files.

## stevenblack-hosts

Bumps the pinned hosts blocklist submodule from `961747e` → `8067d17` (latest StevenBlack/hosts `master` as of 2026-06-24).

## Verification

- `bash -n install.sh`, `zsh -n homedir/.zshrc` pass; `homedir/.gitconfig` parses and `core.excludesfile` → `~/.gitignore.local`.
- Isolated test of the new `install.sh` seeding step: `~/.gitignore.local` is seeded from the baseline + marker, `~/.zshrc.local` stub created, and a second run leaves both untouched (a simulated user edit survived).
- Submodule gitlink recorded at `8067d17`; `git submodule update --init` will fetch it on checkout.
